### PR TITLE
Fixed outdated typescript definition for react causing build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "redux": "^3.6.0"
   },
   "devDependencies": {
-    "@types/react": "^0.14.44",
+    "@types/react": "^16.0.38",
     "@types/react-dom": "^0.14.18",
     "@types/react-redux": "^4.4.32",
     "@types/redux": "^3.6.31",


### PR DESCRIPTION
This fixed the error:

> [TSC] node_modules/@types/react/index.d.ts:165:11 - error TS2559: Type 'Component<P, S>' has no properties in common
with type 'ComponentLifecycle<P, S>'.
[TSC]
[TSC] 165     class Component<P, S> implements ComponentLifecycle<P, S> {